### PR TITLE
Updating Sample App to support dev tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,20 @@ Fragment messagingFragment = new ReactFragment.Builder()
        .build();
 ```
 
+In your Activity make sure to override `onKeyUp()` in order to access the In-App Developer menu:
+
+```java
+@Override
+public boolean onKeyUp(int keyCode, KeyEvent event) {
+    boolean handled = false;
+    Fragment activeFragment = getSupportFragmentManager().findFragmentById(R.id.container_main);
+    if (activeFragment instanceof ReactFragment) {
+        handled = ((ReactFragment) activeFragment).onKeyUp(keyCode, event);
+    }
+    return handled || super.onKeyUp(keyCode, event);
+}
+```
+
 ## Running Sample App
 
 NOTE: Make sure your environment is set up for [React Native](https://facebook.github.io/react-native/docs/getting-started.html) and [Android](https://developer.android.com/training/index.html) development.

--- a/sample-app/android/app/src/main/java/com/hudl/oss/react/sampleapp/MainActivity.java
+++ b/sample-app/android/app/src/main/java/com/hudl/oss/react/sampleapp/MainActivity.java
@@ -1,7 +1,9 @@
 package com.hudl.oss.react.sampleapp;
 
+import android.support.v4.app.Fragment;
 import android.support.v7.app.AppCompatActivity;
 import android.os.Bundle;
+import android.view.KeyEvent;
 
 import com.facebook.react.modules.core.DefaultHardwareBackBtnHandler;
 import com.hudl.oss.react.fragment.ReactFragment;
@@ -28,5 +30,23 @@ public class MainActivity extends AppCompatActivity implements DefaultHardwareBa
     @Override
     public void invokeDefaultOnBackPressed() {
         super.onBackPressed();
+    }
+
+    /**
+     * Forward onKeyUp events to the ReactFragment in order to handle double tap reloads
+     * and dev menus
+     *
+     * @param keyCode
+     * @param event
+     * @return true if event was handled
+     */
+    @Override
+    public boolean onKeyUp(int keyCode, KeyEvent event) {
+        boolean handled = false;
+        Fragment activeFragment = getSupportFragmentManager().findFragmentById(R.id.container_main);
+        if (activeFragment instanceof ReactFragment) {
+            handled = ((ReactFragment) activeFragment).onKeyUp(keyCode, event);
+        }
+        return handled || super.onKeyUp(keyCode, event);
     }
 }


### PR DESCRIPTION
This PR updates the Sample App to allow the React Native dev tools menu to be opened. See https://github.com/hudl/react-native-android-fragment/issues/5

![device-2017-07-26-110641](https://user-images.githubusercontent.com/5814579/28615965-d9286bae-71f2-11e7-87bb-5909fbf37bb4.png)

resolves #5 