### PR TITLE
Don't call destroy host if instance mgr actively used

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ allprojects {
 }
 
 dependencies {
-  // Version will correspond to its dependnecy on React Native
-  compile 'com.github.hudl:react-native-android-fragment:v0.43.2'
+  // Version will correspond to its dependency on React Native
+  compile 'com.github.hudl:react-native-android-fragment:v0.46.2.2'
 }
 ```
 
@@ -25,7 +25,7 @@ Or Maven:
 <dependency>
   <groupId>com.hudl.oss</groupId>
   <artifactId>react-native-android-fragment</artifactId>
-  <version>0.43.2</version>
+  <version>0.46.2.2</version>
 </dependency>
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
-def libraryVersion = '0.43.2'
+def libraryVersion = '0.46.2.2'
 
 buildscript {
     repositories {

--- a/react-native-android-fragment/src/main/java/com/hudl/oss/react/fragment/ReactFragment.java
+++ b/react-native-android-fragment/src/main/java/com/hudl/oss/react/fragment/ReactFragment.java
@@ -155,12 +155,12 @@ public class ReactFragment extends Fragment implements PermissionAwareActivity {
         }
         if (getReactNativeHost().hasInstance()) {
             ReactInstanceManager reactInstanceMgr = getReactNativeHost().getReactInstanceManager();
-            reactInstanceMgr.onHostDestroy(getActivity());
 
             // onDestroy may be called on a ReactFragment after another ReactFragment has been
             // created and resumed with the same React Instance Manager. Make sure we only clean up
             // host's React Instance Manager if no other React Fragment is actively using it.
             if (reactInstanceMgr.getLifecycleState() != LifecycleState.RESUMED) {
+                reactInstanceMgr.onHostDestroy(getActivity());
                 getReactNativeHost().clear();
             }
         }


### PR DESCRIPTION
`ReactInstanceManager`'s `onHostDestroy` resets the manager's lifecycle state and disassociates the manager from any activity. If a react fragment is being destroyed but another react fragment is actively using the manager (manager's lifecycle state is `RESUMED`), we should not call `onHostDestroy` until the last react fragment is destroyed. Otherwise, if the react fragment being destroyed has the same activity as the one actively using the manager, the lifecycle state will be reset to `BEFORE_CREATE` before `ReactFragment`'s `onDestroy` checks if the instance manager is being actively used. In this scenario, `onDestroy` will clean-up the instance manager even though it is still actively being used.

https://github.com/hudl/react-native-android-fragment/pull/11 added the logic to clean-up the instance manager only if it wasn't actively being used. https://github.com/hudl/react-native-android-fragment/pull/11 was created to address an issue arising from react fragments from push notifications being stacked. In the push notification situation, each react fragment was associated with a different activity. https://github.com/hudl/react-native-android-fragment/pull/11 did indeed fix the push notification issue but did not go far enough to fix issues from react fragments associated with the **same** activity being stacked. This PR fixes issues related to premature clean-up for all stacked react fragments, regardless of whether they are associated with the same activity or not.