### PR TITLE
Expose setAppProperties on reactRootView

### DIFF
--- a/android/src/main/java/com/hudl/oss/react/fragment/ReactFragment.java
+++ b/android/src/main/java/com/hudl/oss/react/fragment/ReactFragment.java
@@ -183,6 +183,13 @@ public class ReactFragment extends Fragment implements PermissionAwareActivity {
             getReactNativeHost().getReactInstanceManager().onBackPressed();
         }
     }
+    
+    /**
+     * Helper to update props passed to the React Native Component rendered by the fragment
+     */
+    public void setAppProperties(Bundle appProperties){
+        mReactRootView.setAppProperties(appProperties);
+    }
 
     /**
      * Helper to forward onKeyUp commands from our host Activity.


### PR DESCRIPTION
This allows you to update the properties passed to the fragment. Right now, the only way to set props is as launchOptions.

```java
public void handleNativeButtonClick(){
    rnProps.putString("nativeButtonClicked", "true");
    rnFrag.setAppProperties(newOptions);
}
```