### PR TITLE
updating Readme to add method overrides.

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,33 @@ Fragment messagingFragment = new ReactFragment.Builder()
        .build();
 ```
 
-In your Activity make sure to override `onKeyUp()` in order to access the In-App Developer menu:
+In your Activity make sure to override `onBackPressed()` `onActivityResult()` `onNewIntent` `onKeyUp()` in order to access the In-App Developer menu:
 
 ```java
+@Override
+public void onBackPressed() {
+  Fragment activeFragment = getSupportFragmentManager().findFragmentById(R.id.fragment_container);
+  if (activeFragment instanceof ReactFragment) {
+      ((ReactFragment) activeFragment).onBackPressed();
+  }
+}
+
+@Override
+protected void onActivityResult(int requestCode, int resultCode, Intent data) {
+  Fragment activeFragment = getSupportFragmentManager().findFragmentById(R.id.fragment_container);
+  if (activeFragment instanceof ReactFragment) {
+      ((ReactFragment) activeFragment).onActivityResult(requestCode, resultCode, data);
+  }
+}
+
+@Override
+protected void onNewIntent(Intent intent) {
+  Fragment activeFragment = getSupportFragmentManager().findFragmentById(R.id.fragment_container);
+  if (activeFragment instanceof ReactFragment) {
+      ((ReactFragment) activeFragment).onNewIntent(intent);
+  }
+}
+
 @Override
 public boolean onKeyUp(int keyCode, KeyEvent event) {
     boolean handled = false;


### PR DESCRIPTION
By default fragment doesnot listen to backpress and newIntent event and also listens to onActivityResult only if the activity is called from the fragment, so it is important to override 
`public void onBackPressed()`
`protected void onActivityResult(int requestCode, int resultCode, Intent data)`
`protected void onNewIntent(Intent intent)`

for react-native to work properly.
We are using this in our app in production.