### PR TITLE
Adding onActivityResult and onNewIntent methods in ReactFragment and updating readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,33 @@ Fragment messagingFragment = new ReactFragment.Builder()
        .build();
 ```
 
-In your Activity make sure to override `onKeyUp()` in order to access the In-App Developer menu:
+In your Activity make sure to override `onBackPressed()` `onActivityResult()` `onNewIntent` `onKeyUp()` in order to access the In-App Developer menu:
 
 ```java
+@Override
+public void onBackPressed() {
+  Fragment activeFragment = getSupportFragmentManager().findFragmentById(R.id.fragment_container);
+  if (activeFragment instanceof ReactFragment) {
+      ((ReactFragment) activeFragment).onBackPressed();
+  }
+}
+
+@Override
+protected void onActivityResult(int requestCode, int resultCode, Intent data) {
+  Fragment activeFragment = getSupportFragmentManager().findFragmentById(R.id.fragment_container);
+  if (activeFragment instanceof ReactFragment) {
+      ((ReactFragment) activeFragment).onActivityResult(requestCode, resultCode, data);
+  }
+}
+
+@Override
+protected void onNewIntent(Intent intent) {
+  Fragment activeFragment = getSupportFragmentManager().findFragmentById(R.id.fragment_container);
+  if (activeFragment instanceof ReactFragment) {
+      ((ReactFragment) activeFragment).onNewIntent(intent);
+  }
+}
+
 @Override
 public boolean onKeyUp(int keyCode, KeyEvent event) {
     boolean handled = false;

--- a/android/src/main/java/com/hudl/oss/react/fragment/ReactFragment.java
+++ b/android/src/main/java/com/hudl/oss/react/fragment/ReactFragment.java
@@ -21,6 +21,7 @@ package com.hudl.oss.react.fragment;
 
 import android.annotation.TargetApi;
 import android.app.Activity;
+import android.content.Intent;
 import android.os.Build;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
@@ -181,6 +182,18 @@ public class ReactFragment extends Fragment implements PermissionAwareActivity {
     public void onBackPressed() {
         if (getReactNativeHost().hasInstance()) {
             getReactNativeHost().getReactInstanceManager().onBackPressed();
+        }
+    }
+
+    public void onActivityResult(int requestCode, int resultCode, Intent data) {
+        if (getReactNativeHost().hasInstance()) {
+            getReactNativeHost().getReactInstanceManager().onActivityResult(getActivity(), requestCode, resultCode, data);
+        }
+    }
+
+    public void onNewIntent(Intent intent) {
+        if (getReactNativeHost().hasInstance()) {
+            getReactNativeHost().getReactInstanceManager().onNewIntent(intent);
         }
     }
 

--- a/example/android/app/src/main/java/com/example/MainActivity.java
+++ b/example/android/app/src/main/java/com/example/MainActivity.java
@@ -1,8 +1,9 @@
 package com.example;
 
+import android.content.Intent;
+import android.os.Bundle;
 import android.support.v4.app.Fragment;
 import android.support.v7.app.AppCompatActivity;
-import android.os.Bundle;
 import android.view.KeyEvent;
 
 import com.facebook.react.modules.core.DefaultHardwareBackBtnHandler;
@@ -48,5 +49,29 @@ public class MainActivity extends AppCompatActivity implements DefaultHardwareBa
             handled = ((ReactFragment) activeFragment).onKeyUp(keyCode, event);
         }
         return handled || super.onKeyUp(keyCode, event);
+    }
+
+    @Override
+    public void onBackPressed() {
+        Fragment activeFragment = getSupportFragmentManager().findFragmentById(R.id.container_main);
+        if (activeFragment instanceof ReactFragment) {
+            ((ReactFragment) activeFragment).onBackPressed();
+        }
+    }
+
+    @Override
+    protected void onActivityResult(int requestCode, int resultCode, Intent data) {
+        Fragment activeFragment = getSupportFragmentManager().findFragmentById(R.id.container_main);
+        if (activeFragment instanceof ReactFragment) {
+            ((ReactFragment) activeFragment).onActivityResult(requestCode, resultCode, data);
+        }
+    }
+
+    @Override
+    protected void onNewIntent(Intent intent) {
+        Fragment activeFragment = getSupportFragmentManager().findFragmentById(R.id.container_main);
+        if (activeFragment instanceof ReactFragment) {
+            ((ReactFragment) activeFragment).onNewIntent(intent);
+        }
     }
 }


### PR DESCRIPTION
By default fragment doesnot listen to backpress and newIntent event and also listens to onActivityResult only if the activity is called from the fragment, so it is important to override
`public void onBackPressed()`
`protected void onActivityResult(int requestCode, int resultCode, Intent data)`
`protected void onNewIntent(Intent intent)`

for react-native to work properly.
We are using this in our app in production.

This is an extension of the pr: https://github.com/hudl/react-native-android-fragment/pull/20 that i have raised earlier.