### PR TITLE
Only create the view if needed. 

### DIFF
--- a/android/src/main/java/com/hudl/oss/react/fragment/ReactFragment.java
+++ b/android/src/main/java/com/hudl/oss/react/fragment/ReactFragment.java
@@ -96,11 +96,13 @@ public class ReactFragment extends Fragment implements PermissionAwareActivity {
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container,
                              Bundle savedInstanceState) {
-        mReactRootView = new ReactRootView(getContext());
-        mReactRootView.startReactApplication(
-                getReactNativeHost().getReactInstanceManager(),
-                mComponentName,
-                mLaunchOptions);
+        if (mReactRootView == null) {
+            mReactRootView = new ReactRootView(getContext());
+            mReactRootView.startReactApplication(
+                    getReactNativeHost().getReactInstanceManager(),
+                    mComponentName,
+                    mLaunchOptions);
+        }
         return mReactRootView;
     }
 


### PR DESCRIPTION
Fix for #22 

Use the view already created. This avoid reseting the state of the component and also avoids showing a white flash and reload. 