### PR TITLE
Feature/reuse react view

### DIFF
--- a/android/src/main/java/com/hudl/oss/react/fragment/ReactFragment.java
+++ b/android/src/main/java/com/hudl/oss/react/fragment/ReactFragment.java
@@ -96,11 +96,13 @@ public class ReactFragment extends Fragment implements PermissionAwareActivity {
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container,
                              Bundle savedInstanceState) {
-        mReactRootView = new ReactRootView(getContext());
-        mReactRootView.startReactApplication(
-                getReactNativeHost().getReactInstanceManager(),
-                mComponentName,
-                mLaunchOptions);
+        if (mReactRootView ==null) {
+            mReactRootView = new ReactRootView(getContext());
+            mReactRootView.startReactApplication(
+                    getReactNativeHost().getReactInstanceManager(),
+                    mComponentName,
+                    mLaunchOptions);
+        }
         return mReactRootView;
     }
 

--- a/android/src/main/java/com/hudl/oss/react/fragment/ReactFragment.java
+++ b/android/src/main/java/com/hudl/oss/react/fragment/ReactFragment.java
@@ -135,7 +135,8 @@ public class ReactFragment extends Fragment implements PermissionAwareActivity {
             // onDestroy may be called on a ReactFragment after another ReactFragment has been
             // created and resumed with the same React Instance Manager. Make sure we only clean up
             // host's React Instance Manager if no other React Fragment is actively using it.
-            if (reactInstanceMgr.getLifecycleState() != LifecycleState.RESUMED) {
+            if (reactInstanceMgr.getLifecycleState() != LifecycleState.RESUMED 
+                    && reactInstanceMgr.getLifecycleState() != LifecycleState.BEFORE_RESUME) {
                 reactInstanceMgr.onHostDestroy(getActivity());
                 getReactNativeHost().clear();
             }

--- a/android/src/main/java/com/hudl/oss/react/fragment/ReactFragment.java
+++ b/android/src/main/java/com/hudl/oss/react/fragment/ReactFragment.java
@@ -129,17 +129,17 @@ public class ReactFragment extends Fragment implements PermissionAwareActivity {
             mReactRootView.unmountReactApplication();
             mReactRootView = null;
         }
-        // if (getReactNativeHost().hasInstance()) {
-        //     ReactInstanceManager reactInstanceMgr = getReactNativeHost().getReactInstanceManager();
+        if (getReactNativeHost().hasInstance()) {
+            ReactInstanceManager reactInstanceMgr = getReactNativeHost().getReactInstanceManager();
 
-        //     // onDestroy may be called on a ReactFragment after another ReactFragment has been
-        //     // created and resumed with the same React Instance Manager. Make sure we only clean up
-        //     // host's React Instance Manager if no other React Fragment is actively using it.
-        //     if (reactInstanceMgr.getLifecycleState() != LifecycleState.RESUMED) {
-        //         reactInstanceMgr.onHostDestroy(getActivity());
-        //         getReactNativeHost().clear();
-        //     }
-        // }
+            // onDestroy may be called on a ReactFragment after another ReactFragment has been
+            // created and resumed with the same React Instance Manager. Make sure we only clean up
+            // host's React Instance Manager if no other React Fragment is actively using it.
+            if (reactInstanceMgr.getLifecycleState() != LifecycleState.RESUMED) {
+                reactInstanceMgr.onHostDestroy(getActivity());
+                getReactNativeHost().clear();
+            }
+        }
     }
 
     // endregion

--- a/android/src/main/java/com/hudl/oss/react/fragment/ReactFragment.java
+++ b/android/src/main/java/com/hudl/oss/react/fragment/ReactFragment.java
@@ -129,17 +129,17 @@ public class ReactFragment extends Fragment implements PermissionAwareActivity {
             mReactRootView.unmountReactApplication();
             mReactRootView = null;
         }
-        if (getReactNativeHost().hasInstance()) {
-            ReactInstanceManager reactInstanceMgr = getReactNativeHost().getReactInstanceManager();
+        // if (getReactNativeHost().hasInstance()) {
+        //     ReactInstanceManager reactInstanceMgr = getReactNativeHost().getReactInstanceManager();
 
-            // onDestroy may be called on a ReactFragment after another ReactFragment has been
-            // created and resumed with the same React Instance Manager. Make sure we only clean up
-            // host's React Instance Manager if no other React Fragment is actively using it.
-            if (reactInstanceMgr.getLifecycleState() != LifecycleState.RESUMED) {
-                reactInstanceMgr.onHostDestroy(getActivity());
-                getReactNativeHost().clear();
-            }
-        }
+        //     // onDestroy may be called on a ReactFragment after another ReactFragment has been
+        //     // created and resumed with the same React Instance Manager. Make sure we only clean up
+        //     // host's React Instance Manager if no other React Fragment is actively using it.
+        //     if (reactInstanceMgr.getLifecycleState() != LifecycleState.RESUMED) {
+        //         reactInstanceMgr.onHostDestroy(getActivity());
+        //         getReactNativeHost().clear();
+        //     }
+        // }
     }
 
     // endregion


### PR DESCRIPTION
Fix for #22 and possibly #18.  

A new root view is only created when there is not one. This allows the back stack to show an old view without rendering it again. To do this successfully though onDestroy needs to allow LifecycleState.BEFORE_RESUME as a good state because in my testing if you are on a react view and tap back onDestroy will kill the instance manager and the view that is shown will no longer have an instance manager. 